### PR TITLE
Feature/install bash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 FROM node:16-alpine3.15
 
 
-# Install bash, python and pip 
+# Install python and pip 
 ENV PYTHONUNBUFFERED=1
-RUN apk add --update --no-cache python3 bash && ln -sf python3 /usr/bin/python
+RUN apk add --update --no-cache python3 && ln -sf python3 /usr/bin/python
 RUN python3 -m ensurepip
 RUN pip3 install --no-cache --upgrade pip setuptools
+
+# Install Bash
+RUN apk update bash
 
 COPY requirements.txt /
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM node:16-alpine3.15
 
 
-# Install python and pip
+# Install bash, python and pip 
 ENV PYTHONUNBUFFERED=1
-RUN apk add --update --no-cache python3 && ln -sf python3 /usr/bin/python
+RUN apk add --update --no-cache python3 bash && ln -sf python3 /usr/bin/python
 RUN python3 -m ensurepip
 RUN pip3 install --no-cache --upgrade pip setuptools
 


### PR DESCRIPTION
It has been identified that some cdk libraries have a dependency on `bash`. 

This pull request, prematurely add `bash` to the container.

Note: Before scripts can't be used to run `apk` commands without altering the permissions on `node` user.