### PR TITLE
Fix/before and after script defaults

### DIFF
--- a/pipe/pipe.py
+++ b/pipe/pipe.py
@@ -124,7 +124,7 @@ class CDKDeployPipe(Pipe):
                 return None, err
             combined_output += err
 
-        if runtime_script is not None:
+        if runtime_script is not None and len(runtime_script) > 0:
             status, err = self.__scriptRunner(working_dir, runtime_script.split(";"))
             if not status:
                 return None, err


### PR DESCRIPTION
There are some cases  we might need let CDK_BEFORE_SCRIPT env to be empty rather than setting it. This PR intended to accommodate such scenarios.
