### PR TITLE
Removed npm install from the static script

### DIFF
--- a/cdk-config.yml
+++ b/cdk-config.yml
@@ -8,7 +8,7 @@ cdk-pipe:
     npm:
        install: npm ci
   beforeScripts:
-    - npm install 
+    - npm version 
   # afterScripts:
   #   - apk add tree
 


### PR DESCRIPTION
It seems we are not required to and we should not be doing `npm install` during a pipeline, as this may cause unexpected behaviours.