### PR TITLE
Linting and formatting check

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ When setting before and after scripts using environment variables, use `;` to se
 
 ### Linting and Formatting Checks  
 
-Linting and Formatting checks against the CDK code can be executed at runtime.  
+Linting and Formatting checks against the CDK code can be executed at build time.  
 Required packages and configurations should be included as a apart of the infrastructure code.  
 The default execution commands are defined as a part of [static config]  
 

--- a/README.md
+++ b/README.md
@@ -8,18 +8,21 @@ A BitBucket pipe to deploy CDK Stacks
 
 Static config is a `yaml` script which can be used to configure and customise the behaviour of the cdk commands.
 
-```sh
+```yaml
 cdk-pipe:
   commands:
-    cdk: 
+    cdk:
       bootstrap: npx cdk bootstrap
       deploy: npx cdk deploy
       synth: npx cdk synth
       diff: npx cdk diff
     npm:
-       install: npm ci
+      checks:
+        lint: npm run lint
+        format: npm run format
+      install: npm ci
   beforeScripts:
-    - npm install 
+    - npm version
   afterScripts:
     - echo "Deployment is completed"
 ```
@@ -33,6 +36,27 @@ As the name suggests, the before and after scripts can be used to extend the beh
 Both `static config script` and environment variables (`CDK_BEFORE_SCRIPT`, `CDK_AFTER_SCRIPT`) can be used in the context.
 When setting before and after scripts using environment variables, use `;` to separate the statements.
 
+### Linting and Formatting Checks  
+
+Linting and Formatting checks against the CDK code can be executed at runtime.  
+Required packages and configurations should be included as a apart of the infrastructure code.  
+The default execution commands are defined as a part of [static config]  
+
+```yaml
+cdk-pipe:
+  commands:
+    cdk:
+      ...
+    npm:
+      checks:
+        lint: npm run lint
+        format: npm run format
+      ...
+```
+
+*Note: If the linting and formatting commands in package.json supposed to auto-correct the issues, you may either use a custom `static config` file with a custom set of commands, or `CHECK_LINT_CMD`/`CHECK_FORMAT_CMD` to override them*  
+__If `CHECK_LINT_CMD`/`CHECK_FORMAT_CMD` has been set, it is not required to set `CHECK_LINT`/`CHECK_FORMAT`__
+
 ### CDK_EXTRA_ARGS
 
 `CDK_EXTRA_ARGS` environment variable only to be associated, when it is required to append additional arguments to `cdk deploy` command.
@@ -44,7 +68,7 @@ If it is required to extend `diff`, `synth` or `bootstrap` commands, `CDK_EXTRA_
 
 Minimum configuration
 
-```sh
+```yaml
 - step:
     name: "CDK Deploy"
     script:
@@ -58,19 +82,23 @@ Minimum configuration
 
 | Variable | Usage | Defaults |
 |:----------|:-------|:-------|
-| AWS_ACCESS_KEY_ID             | AWS access key id for CDK deployment                                                  |   N/A                 |
-| AWS_SECRET_ACCESS_KEY         | AWS secret key for CDK deployment                                                     |   N/A                 |
-| AWS_DEFAULT_REGION            | Default AWS region                                                                    |   `Nil`               |
-| CDK_ROOT_DIR                  | The working directory where the `cdk` commands should executed                         |   `./`                |
-| DEBUG                         | To enable debug logs                                                                  |   `false`             |
-| CDK_BOOTSTRAP                 | Set this to `true` if it is required to bootstrap the stack prior to the deployment      |   `false`             |
-| CDK_SYNTH                     | Set this to `true` if it is required to run synth on the stack prior to the deployment   |   `false`             |
-| CDK_DIFF                      | Set this to `true` if it is required to run diff on the stack prior to the deployment    |   `false`             |
-| CDK_DEPLOY                    | Set this to `false` to skip CDK deployment                                            |   `true`              |
-| CDK_BEFORE_SCRIPT             | Set to extend the before script which is configured using the static config           |   `Nil`               |
-| CDK_AFTER_SCRIPT              | Set to extend the after script which is configured using the static config            |   `Nil`               |
-| CDK_EXTRA_ARGS                | Set to extend CDK deployment statement which is configured in the static config        |   `Nil`               |
-| CDK_CONFIG_PATH               | Set this if a custom static config should be associated                                    |   `./cdk-config.yml`  |
+| AWS_ACCESS_KEY_ID             | AWS access key id for CDK deployment                                                        |   N/A                 |
+| AWS_SECRET_ACCESS_KEY         | AWS secret key for CDK deployment                                                           |   N/A                 |
+| AWS_DEFAULT_REGION            | Default AWS region                                                                          |   `Nil`               |
+| CDK_ROOT_DIR                  | The working directory where the `cdk` commands should executed                              |   `./`                |
+| DEBUG                         | To enable debug logs                                                                        |   `false`             |
+| CDK_BOOTSTRAP                 | Set this to `true` if it is required to bootstrap the stack prior to the deployment         |   `false`             |
+| CDK_SYNTH                     | Set this to `true` if it is required to run synth on the stack prior to the deployment      |   `false`             |
+| CDK_DIFF                      | Set this to `true` if it is required to run diff on the stack prior to the deployment       |   `false`             |
+| CDK_DEPLOY                    | Set this to `false` to skip CDK deployment                                                  |   `true`              |
+| CDK_BEFORE_SCRIPT             | Set to extend the before script which is configured using the static config                 |   `Nil`               |
+| CDK_AFTER_SCRIPT              | Set to extend the after script which is configured using the static config                  |   `Nil`               |
+| CDK_EXTRA_ARGS                | Set to extend CDK deployment statement which is configured in the static config             |   `Nil`               |
+| CDK_CONFIG_PATH               | Set this if a custom static config should be associated                                     |   `./cdk-config.yml`  |
+| CHECK_LINT                    | Set this to `true` to validate the linting                                                  |  `false`              |
+| CHECK_FORMAT                  | Set this to `true` to validate the formatting                                               |  `false`              |
+| CHECK_LINT_CMD                | Use this to override default linting command from [static config], *(this would set `CHECK_LINT`)*                             |  `false`              |
+| CHECK_FORMAT_CMD              | Use this to override default formatting command from [static config], *(this would set `CHECK_FORMAT`)*                        |  `false`              |
 
 ## Development
 
@@ -84,7 +112,7 @@ To build and run locally
 
 To execute the cdk processes, python [subprocess] library has been used. To alter this with a new library use `__scriptRunner()` function
 
-```sh
+```python
     def __scriptRunner(self, working_dir, arr):
         # Change working Directory
         ...
@@ -96,4 +124,5 @@ To execute the cdk processes, python [subprocess] library has been used. To alte
         return True, combined_output
 ```
 
-[subprocess]:(https://docs.python.org/3/library/subprocess.html)
+[subprocess]:(https://docs.python.org/3/library/subprocess.html)  
+[static config]:cdk-config.yml

--- a/cdk-config.yml
+++ b/cdk-config.yml
@@ -1,15 +1,16 @@
 cdk-pipe:
   commands:
-    cdk: 
+    cdk:
       bootstrap: npx cdk bootstrap
       deploy: npx cdk deploy
       synth: npx cdk synth
       diff: npx cdk diff
     npm:
-       install: npm ci
+      checks:
+        lint: npm run lint
+        format: npm run format
+      install: npm ci
   beforeScripts:
-    - npm version 
+    - npm version
   # afterScripts:
   #   - apk add tree
-
-      

--- a/pipe/pipe.py
+++ b/pipe/pipe.py
@@ -165,7 +165,7 @@ class CDKDeployPipe(Pipe):
                 if not status:
                     return Exception('check linting: ' + str(err)) 
             except Exception as exception:
-                return Exception('linting check failed: ' + str(exception))# NPM Format check
+                return Exception('linting check failed: ' + str(exception))
         
         # NPM Formatting check
         if (self.check_format and self.cmd_npm_format) or self.check_format_override:


### PR DESCRIPTION
This feature let us run linting and formatting check as a part of the deploy pipe.

### Linting and Formatting Checks  

Linting and Formatting checks against the CDK code can be executed at runtime.  
Required packages and configurations should be included as a apart of the infrastructure code.  
The default execution commands are defined as a part of static config script

```yaml
cdk-pipe:
  commands:
    cdk:
      ...
    npm:
      checks:
        lint: npm run lint
        format: npm run format
      ...
```

*Note: If the linting and formatting commands in package.json supposed to auto-correct the issues, you may either use a custom `static config` file with a custom set of commands, or `CHECK_LINT_CMD`/`CHECK_FORMAT_CMD` to override them*  
__If `CHECK_LINT_CMD`/`CHECK_FORMAT_CMD` has been set, it is not required to set `CHECK_LINT`/`CHECK_FORMAT`__
