### PR TITLE
DO-1523: add node tag config via build hook

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:18-alpine3.17
+ARG NODE_TAG
+FROM node:${NODE_TAG}
 
 # Install python and pip 
 ENV PYTHONUNBUFFERED=1

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker build --build-arg NODE_TAG="$(echo $DOCKER_TAG | sed 's/-experimental//g')" -f $DOCKERFILE_PATH -t $IMAGE_NAME .


### PR DESCRIPTION
In order to keep this pipeline up to date I've modified the base node image to use a customizable docker tag. This is then controlled by the build process in docker hub: 

![image](https://github.com/aligent/cdk-deploy-pipe/assets/6127662/3dd72826-6ce0-447b-87e3-843c7e647f0e)

