### PR TITLE
Enable Yarn via Corepack in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ RUN python3 -m venv /venv && \
     PIP_CONSTRAINT=cython_constraint.txt pip install --no-cache-dir -r requirements.txt
 ENV PATH="/venv/bin:$PATH"
 
+RUN corepack enable yarn
+
 USER node
 
 ENTRYPOINT ["python", "/pipe.py"]


### PR DESCRIPTION
Added corepack enable yarn to the Dockerfile before switching to the node user to ensure Yarn is globally available in the container. This allows us to use yarn in Bitbucket Pipelines when building or deploying with this image.