### PR TITLE
chore: set default NODE_TAG to 24-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG NODE_TAG
-FROM node:${NODE_TAG}
+FROM node:${NODE_TAG:-24-alpine}
 
 # Install python3, pip and bash
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
**Description of the proposed changes**

Use node 24 as the default. This way we can build a "latest" image.

Notes to reviewers

ℹ️ When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback

